### PR TITLE
Added `delete()` and `deleteMany()` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The API mimics Prisma Client's API for ease of use:
 Insert a new record:
 
 ```javascript
-db.modelName.create({
+idbClient.modelName.create({
   data: {
     field: value,
   },
@@ -97,7 +97,7 @@ db.modelName.create({
 Retrieve all records:
 
 ```javascript
-db.modelName.findMany();
+idbClient.modelName.findMany();
 ```
 
 ### `findUnique`
@@ -105,7 +105,7 @@ db.modelName.findMany();
 Retrieve a single record by unique key:
 
 ```javascript
-db.modelName.findUnique({
+idbClient.modelName.findUnique({
   where: { key: value },
 });
 ```
@@ -115,7 +115,7 @@ db.modelName.findUnique({
 Update a record:
 
 ```javascript
-db.modelName.update({
+idbClient.modelName.update({
   where: { key: value },
   data: { key: newValue },
 });
@@ -126,7 +126,7 @@ db.modelName.update({
 Delete a record:
 
 ```javascript
-db.modelName.delete({
+idbClient.modelName.delete({
   where: { key: value },
 });
 ```

--- a/packages/generator/src/fileCreators/prisma-idb-client/classes/models/IDBModelClass.ts
+++ b/packages/generator/src/fileCreators/prisma-idb-client/classes/models/IDBModelClass.ts
@@ -18,6 +18,8 @@ import { addGetNeededStoresForCreate } from "./utils/_getNeededStoresForCreate";
 import { addGetNeededStoresForFind } from "./utils/_getNeededStoresForFind";
 import { addRemoveNestedCreateDataMethod } from "./utils/_removeNestedCreateData";
 import { addGetNeededStoresForWhere } from "./utils/_getNeededStoresForWhere";
+import { addDeleteMethod } from "./api/delete";
+import { addDeleteManyMethod } from "./api/deleteMany";
 
 export function addIDBModelClass(file: SourceFile, model: Model, models: readonly Model[]) {
   const modelClass = file.addClass({
@@ -44,6 +46,9 @@ export function addIDBModelClass(file: SourceFile, model: Model, models: readonl
   addCreateMethod(modelClass, model, models);
   addCreateManyMethod(modelClass, model);
   addCreateManyAndReturn(modelClass, model);
+
+  addDeleteMethod(modelClass, model, models);
+  addDeleteManyMethod(modelClass, model, models);
 
   addUpdateMethod(modelClass, model);
 }

--- a/packages/generator/src/fileCreators/prisma-idb-client/classes/models/api/delete.ts
+++ b/packages/generator/src/fileCreators/prisma-idb-client/classes/models/api/delete.ts
@@ -48,9 +48,8 @@ function handleCascadeDeletes(writer: CodeBlockWriter, model: Model, models: rea
       (field) => field.relationOnDelete === "Cascade" && field.type === model.name,
     );
     for (const cascadingFk of cascadingFks) {
-      const { isList } = model.fields.find(({ relationName }) => relationName === cascadingFk.relationName)!;
       writer
-        .write(`await this.client.${toCamelCase(cascadeModel.name)}.${isList ? `deleteMany` : `delete`}(`)
+        .write(`await this.client.${toCamelCase(cascadeModel.name)}.deleteMany(`)
         .block(() => {
           const fk = cascadingFk.relationFromFields?.at(0);
           const pk = cascadingFk.relationToFields?.at(0);

--- a/packages/generator/src/fileCreators/prisma-idb-client/classes/models/api/delete.ts
+++ b/packages/generator/src/fileCreators/prisma-idb-client/classes/models/api/delete.ts
@@ -1,0 +1,66 @@
+import { toCamelCase } from "../../../../../helpers/utils";
+import { Model } from "../../../../../fileCreators/types";
+import { ClassDeclaration, CodeBlockWriter } from "ts-morph";
+
+export function addDeleteMethod(modelClass: ClassDeclaration, model: Model, models: readonly Model[]) {
+  modelClass.addMethod({
+    name: "delete",
+    isAsync: true,
+    typeParameters: [{ name: "Q", constraint: `Prisma.Args<Prisma.${model.name}Delegate, 'delete'>` }],
+    parameters: [
+      { name: "query", type: "Q" },
+      {
+        name: "tx",
+        hasQuestionToken: true,
+        type: "IDBUtils.ReadwriteTransactionType",
+      },
+    ],
+    returnType: `Promise<Prisma.Result<Prisma.${model.name}Delegate, Q, 'delete'>>`,
+    statements: (writer) => {
+      createTxAndGetRecord(writer, model, models);
+      handleCascadeDeletes(writer, model, models);
+      deleteAndReturnRecord(writer, model);
+    },
+  });
+}
+
+function createTxAndGetRecord(writer: CodeBlockWriter, model: Model, models: readonly Model[]) {
+  writer.writeLine(`const storesNeeded = this._getNeededStoresForFind(query);`);
+  const cascadingModels = models.filter((_model) =>
+    _model.fields.some((field) => field.relationOnDelete === "Cascade" && field.type === model.name),
+  );
+  for (const cascadeModel of cascadingModels) {
+    writer.writeLine(`storesNeeded.add("${cascadeModel.name}")`);
+  }
+
+  writer
+    .writeLine(`tx = tx ?? this.client._db.transaction(Array.from(storesNeeded), "readwrite");`)
+    .writeLine(`const record = await this.findUnique(query, tx);`)
+    .writeLine(`if (!record) throw new Error("Record not found");`);
+}
+
+function handleCascadeDeletes(writer: CodeBlockWriter, model: Model, models: readonly Model[]) {
+  const cascadingModels = models.filter((_model) =>
+    _model.fields.some((field) => field.relationOnDelete === "Cascade" && field.type === model.name),
+  );
+  for (const cascadeModel of cascadingModels) {
+    const cascadingFks = cascadeModel.fields.filter(
+      (field) => field.relationOnDelete === "Cascade" && field.type === model.name,
+    );
+    for (const cascadingFk of cascadingFks) {
+      const { isList } = model.fields.find(({ relationName }) => relationName === cascadingFk.relationName)!;
+      writer
+        .write(`await this.client.${toCamelCase(cascadeModel.name)}.${isList ? `deleteMany` : `delete`}(`)
+        .block(() => {
+          const fk = cascadingFk.relationFromFields?.at(0);
+          const pk = cascadingFk.relationToFields?.at(0);
+          writer.write(`where: { ${fk}: record.${pk} }`);
+        })
+        .writeLine(`, tx)`);
+    }
+  }
+}
+
+function deleteAndReturnRecord(writer: CodeBlockWriter, model: Model) {
+  writer.writeLine(`await tx.objectStore("${model.name}").delete([record.id]);`).writeLine(`return record;`);
+}

--- a/packages/generator/src/fileCreators/prisma-idb-client/classes/models/api/deleteMany.ts
+++ b/packages/generator/src/fileCreators/prisma-idb-client/classes/models/api/deleteMany.ts
@@ -1,0 +1,46 @@
+import { ClassDeclaration, CodeBlockWriter } from "ts-morph";
+import { Model } from "../../../../../fileCreators/types";
+import { getUniqueIdentifiers } from "../../../../../helpers/utils";
+
+export function addDeleteManyMethod(modelClass: ClassDeclaration, model: Model, models: readonly Model[]) {
+  modelClass.addMethod({
+    name: "deleteMany",
+    isAsync: true,
+    typeParameters: [{ name: "Q", constraint: `Prisma.Args<Prisma.${model.name}Delegate, 'deleteMany'>` }],
+    parameters: [
+      { name: "query", type: "Q" },
+      {
+        name: "tx",
+        hasQuestionToken: true,
+        type: "IDBUtils.ReadwriteTransactionType",
+      },
+    ],
+    returnType: `Promise<Prisma.Result<Prisma.${model.name}Delegate, Q, 'deleteMany'>>`,
+    statements: (writer) => {
+      createTxAndGetRecord(writer, model, models);
+      deleteRecords(writer, model);
+      writer.writeLine(`return { count: records.length };`);
+    },
+  });
+}
+
+function createTxAndGetRecord(writer: CodeBlockWriter, model: Model, models: readonly Model[]) {
+  writer.writeLine(`const storesNeeded = this._getNeededStoresForFind(query);`);
+  const cascadingModels = models.filter((_model) =>
+    _model.fields.some((field) => field.relationOnDelete === "Cascade" && field.type === model.name),
+  );
+  for (const cascadeModel of cascadingModels) {
+    writer.writeLine(`storesNeeded.add("${cascadeModel.name}")`);
+  }
+
+  writer
+    .writeLine(`tx = tx ?? this.client._db.transaction(Array.from(storesNeeded), "readwrite");`)
+    .writeLine(`const records = await this.findMany(query, tx);`);
+}
+
+function deleteRecords(writer: CodeBlockWriter, model: Model) {
+  const pkOfModel = JSON.parse(getUniqueIdentifiers(model)[0].keyPath)[0];
+  writer.writeLine(`for (const record of records)`).block(() => {
+    writer.writeLine(`await this.delete({ where: { ${pkOfModel}: record.${pkOfModel} } }, tx);`);
+  });
+}

--- a/packages/usage/src/prisma/prisma-idb/prisma-idb-client.ts
+++ b/packages/usage/src/prisma/prisma-idb/prisma-idb-client.ts
@@ -631,7 +631,7 @@ class UserIDBClass extends BaseIDBModelClass {
     tx = tx ?? this.client._db.transaction(Array.from(storesNeeded), "readwrite");
     const record = await this.findUnique(query, tx);
     if (!record) throw new Error("Record not found");
-    await this.client.profile.delete(
+    await this.client.profile.deleteMany(
       {
         where: { userId: record.id },
       },

--- a/packages/usage/src/prisma/prisma-idb/prisma-idb-client.ts
+++ b/packages/usage/src/prisma/prisma-idb/prisma-idb-client.ts
@@ -621,6 +621,47 @@ class UserIDBClass extends BaseIDBModelClass {
     return records as Prisma.Result<Prisma.UserDelegate, Q, "createManyAndReturn">;
   }
 
+  async delete<Q extends Prisma.Args<Prisma.UserDelegate, "delete">>(
+    query: Q,
+    tx?: IDBUtils.ReadwriteTransactionType,
+  ): Promise<Prisma.Result<Prisma.UserDelegate, Q, "delete">> {
+    const storesNeeded = this._getNeededStoresForFind(query);
+    storesNeeded.add("Profile");
+    storesNeeded.add("Comment");
+    tx = tx ?? this.client._db.transaction(Array.from(storesNeeded), "readwrite");
+    const record = await this.findUnique(query, tx);
+    if (!record) throw new Error("Record not found");
+    await this.client.profile.delete(
+      {
+        where: { userId: record.id },
+      },
+      tx,
+    );
+    await this.client.comment.deleteMany(
+      {
+        where: { userId: record.id },
+      },
+      tx,
+    );
+    await tx.objectStore("User").delete([record.id]);
+    return record;
+  }
+
+  async deleteMany<Q extends Prisma.Args<Prisma.UserDelegate, "deleteMany">>(
+    query: Q,
+    tx?: IDBUtils.ReadwriteTransactionType,
+  ): Promise<Prisma.Result<Prisma.UserDelegate, Q, "deleteMany">> {
+    const storesNeeded = this._getNeededStoresForFind(query);
+    storesNeeded.add("Profile");
+    storesNeeded.add("Comment");
+    tx = tx ?? this.client._db.transaction(Array.from(storesNeeded), "readwrite");
+    const records = await this.findMany(query, tx);
+    for (const record of records) {
+      await this.delete({ where: { id: record.id } }, tx);
+    }
+    return { count: records.length };
+  }
+
   async update<Q extends Prisma.Args<Prisma.UserDelegate, "update">>(
     query: Q,
     tx?: IDBUtils.ReadwriteTransactionType,
@@ -984,6 +1025,31 @@ class ProfileIDBClass extends BaseIDBModelClass {
       records.push(this._applySelectClause([record], query.select)[0]);
     }
     return records as Prisma.Result<Prisma.ProfileDelegate, Q, "createManyAndReturn">;
+  }
+
+  async delete<Q extends Prisma.Args<Prisma.ProfileDelegate, "delete">>(
+    query: Q,
+    tx?: IDBUtils.ReadwriteTransactionType,
+  ): Promise<Prisma.Result<Prisma.ProfileDelegate, Q, "delete">> {
+    const storesNeeded = this._getNeededStoresForFind(query);
+    tx = tx ?? this.client._db.transaction(Array.from(storesNeeded), "readwrite");
+    const record = await this.findUnique(query, tx);
+    if (!record) throw new Error("Record not found");
+    await tx.objectStore("Profile").delete([record.id]);
+    return record;
+  }
+
+  async deleteMany<Q extends Prisma.Args<Prisma.ProfileDelegate, "deleteMany">>(
+    query: Q,
+    tx?: IDBUtils.ReadwriteTransactionType,
+  ): Promise<Prisma.Result<Prisma.ProfileDelegate, Q, "deleteMany">> {
+    const storesNeeded = this._getNeededStoresForFind(query);
+    tx = tx ?? this.client._db.transaction(Array.from(storesNeeded), "readwrite");
+    const records = await this.findMany(query, tx);
+    for (const record of records) {
+      await this.delete({ where: { id: record.id } }, tx);
+    }
+    return { count: records.length };
   }
 
   async update<Q extends Prisma.Args<Prisma.ProfileDelegate, "update">>(
@@ -1481,6 +1547,39 @@ class PostIDBClass extends BaseIDBModelClass {
     return records as Prisma.Result<Prisma.PostDelegate, Q, "createManyAndReturn">;
   }
 
+  async delete<Q extends Prisma.Args<Prisma.PostDelegate, "delete">>(
+    query: Q,
+    tx?: IDBUtils.ReadwriteTransactionType,
+  ): Promise<Prisma.Result<Prisma.PostDelegate, Q, "delete">> {
+    const storesNeeded = this._getNeededStoresForFind(query);
+    storesNeeded.add("Comment");
+    tx = tx ?? this.client._db.transaction(Array.from(storesNeeded), "readwrite");
+    const record = await this.findUnique(query, tx);
+    if (!record) throw new Error("Record not found");
+    await this.client.comment.deleteMany(
+      {
+        where: { postId: record.id },
+      },
+      tx,
+    );
+    await tx.objectStore("Post").delete([record.id]);
+    return record;
+  }
+
+  async deleteMany<Q extends Prisma.Args<Prisma.PostDelegate, "deleteMany">>(
+    query: Q,
+    tx?: IDBUtils.ReadwriteTransactionType,
+  ): Promise<Prisma.Result<Prisma.PostDelegate, Q, "deleteMany">> {
+    const storesNeeded = this._getNeededStoresForFind(query);
+    storesNeeded.add("Comment");
+    tx = tx ?? this.client._db.transaction(Array.from(storesNeeded), "readwrite");
+    const records = await this.findMany(query, tx);
+    for (const record of records) {
+      await this.delete({ where: { id: record.id } }, tx);
+    }
+    return { count: records.length };
+  }
+
   async update<Q extends Prisma.Args<Prisma.PostDelegate, "update">>(
     query: Q,
     tx?: IDBUtils.ReadwriteTransactionType,
@@ -1927,6 +2026,31 @@ class CommentIDBClass extends BaseIDBModelClass {
     return records as Prisma.Result<Prisma.CommentDelegate, Q, "createManyAndReturn">;
   }
 
+  async delete<Q extends Prisma.Args<Prisma.CommentDelegate, "delete">>(
+    query: Q,
+    tx?: IDBUtils.ReadwriteTransactionType,
+  ): Promise<Prisma.Result<Prisma.CommentDelegate, Q, "delete">> {
+    const storesNeeded = this._getNeededStoresForFind(query);
+    tx = tx ?? this.client._db.transaction(Array.from(storesNeeded), "readwrite");
+    const record = await this.findUnique(query, tx);
+    if (!record) throw new Error("Record not found");
+    await tx.objectStore("Comment").delete([record.id]);
+    return record;
+  }
+
+  async deleteMany<Q extends Prisma.Args<Prisma.CommentDelegate, "deleteMany">>(
+    query: Q,
+    tx?: IDBUtils.ReadwriteTransactionType,
+  ): Promise<Prisma.Result<Prisma.CommentDelegate, Q, "deleteMany">> {
+    const storesNeeded = this._getNeededStoresForFind(query);
+    tx = tx ?? this.client._db.transaction(Array.from(storesNeeded), "readwrite");
+    const records = await this.findMany(query, tx);
+    for (const record of records) {
+      await this.delete({ where: { id: record.id } }, tx);
+    }
+    return { count: records.length };
+  }
+
   async update<Q extends Prisma.Args<Prisma.CommentDelegate, "update">>(
     query: Q,
     tx?: IDBUtils.ReadwriteTransactionType,
@@ -2257,6 +2381,31 @@ class AllFieldScalarTypesIDBClass extends BaseIDBModelClass {
       records.push(this._applySelectClause([record], query.select)[0]);
     }
     return records as Prisma.Result<Prisma.AllFieldScalarTypesDelegate, Q, "createManyAndReturn">;
+  }
+
+  async delete<Q extends Prisma.Args<Prisma.AllFieldScalarTypesDelegate, "delete">>(
+    query: Q,
+    tx?: IDBUtils.ReadwriteTransactionType,
+  ): Promise<Prisma.Result<Prisma.AllFieldScalarTypesDelegate, Q, "delete">> {
+    const storesNeeded = this._getNeededStoresForFind(query);
+    tx = tx ?? this.client._db.transaction(Array.from(storesNeeded), "readwrite");
+    const record = await this.findUnique(query, tx);
+    if (!record) throw new Error("Record not found");
+    await tx.objectStore("AllFieldScalarTypes").delete([record.id]);
+    return record;
+  }
+
+  async deleteMany<Q extends Prisma.Args<Prisma.AllFieldScalarTypesDelegate, "deleteMany">>(
+    query: Q,
+    tx?: IDBUtils.ReadwriteTransactionType,
+  ): Promise<Prisma.Result<Prisma.AllFieldScalarTypesDelegate, Q, "deleteMany">> {
+    const storesNeeded = this._getNeededStoresForFind(query);
+    tx = tx ?? this.client._db.transaction(Array.from(storesNeeded), "readwrite");
+    const records = await this.findMany(query, tx);
+    for (const record of records) {
+      await this.delete({ where: { id: record.id } }, tx);
+    }
+    return { count: records.length };
   }
 
   async update<Q extends Prisma.Args<Prisma.AllFieldScalarTypesDelegate, "update">>(

--- a/packages/usage/src/prisma/schema.prisma
+++ b/packages/usage/src/prisma/schema.prisma
@@ -39,9 +39,9 @@ model Post {
 
 model Comment {
   id     String @id @default(cuid())
-  post   Post   @relation(fields: [postId], references: [id])
+  post   Post   @relation(fields: [postId], references: [id], onDelete: Cascade)
   postId Int
-  user   User   @relation(fields: [userId], references: [id])
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId Int
   text   String
 }

--- a/packages/usage/tests/modelQueries/delete.spec.ts
+++ b/packages/usage/tests/modelQueries/delete.spec.ts
@@ -1,0 +1,35 @@
+import { test } from "../fixtures";
+import { expectQueryToFail, expectQueryToSucceed } from "../queryRunnerHelper";
+
+test("delete_NoMatchingRecord_ThrowsError", async ({ page }) => {
+  await expectQueryToFail({
+    page,
+    model: "user",
+    operation: "delete",
+    query: { where: { id: 1 } },
+    errorMessage: "Record not found",
+  });
+});
+
+test("delete_ExistingRecord_DeletesAndReturnsFirstRecord", async ({ page }) => {
+  await expectQueryToSucceed({ page, model: "user", operation: "create", query: { data: { name: "John" } } });
+  await expectQueryToSucceed({ page, model: "user", operation: "delete", query: { where: { id: 1 } } });
+  await expectQueryToSucceed({ page, model: "user", operation: "findMany" });
+});
+
+test("delete_ExistingRecordWithCascade_DeletesAndReturnsFirstRecordWithRelation", async ({ page }) => {
+  await expectQueryToSucceed({
+    page,
+    model: "user",
+    operation: "create",
+    query: { data: { name: "John", profile: { create: { bio: "John's bio" } } } },
+  });
+
+  await expectQueryToSucceed({
+    page,
+    model: "user",
+    operation: "delete",
+    query: { where: { id: 1 }, include: { profile: true } },
+  });
+  await expectQueryToSucceed({ page, model: "profile", operation: "findMany", query: { include: { user: true } } });
+});

--- a/packages/usage/tests/modelQueries/deleteMany.spec.ts
+++ b/packages/usage/tests/modelQueries/deleteMany.spec.ts
@@ -1,0 +1,45 @@
+import { test } from "../fixtures";
+import { expectQueryToSucceed } from "../queryRunnerHelper";
+
+test("deleteMany_NoMatchingRecord_ReturnsCount0", async ({ page }) => {
+  await expectQueryToSucceed({
+    page,
+    model: "user",
+    operation: "deleteMany",
+    query: { where: { id: 1 } },
+  });
+});
+
+test("deleteMany_AllRecords_DeletesAndReturnsCount", async ({ page }) => {
+  await expectQueryToSucceed({
+    page,
+    model: "user",
+    operation: "createMany",
+    query: { data: [{ name: "John" }, { name: "Alice" }] },
+  });
+  await expectQueryToSucceed({ page, model: "user", operation: "deleteMany" });
+  await expectQueryToSucceed({ page, model: "user", operation: "findMany" });
+});
+
+test("delete_AllRecordsWithRelations_CascadeDeletesProfile", async ({ page }) => {
+  await expectQueryToSucceed({
+    page,
+    model: "user",
+    operation: "create",
+    query: { data: { name: "John", profile: { create: { bio: "John's bio" } } } },
+  });
+  await expectQueryToSucceed({
+    page,
+    model: "user",
+    operation: "create",
+    query: { data: { name: "Alice", profile: { create: { bio: "Alice's bio" } } } },
+  });
+
+  await expectQueryToSucceed({
+    page,
+    model: "user",
+    operation: "deleteMany",
+  });
+  await expectQueryToSucceed({ page, model: "profile", operation: "findMany" });
+  await expectQueryToSucceed({ page, model: "user", operation: "findMany" });
+});


### PR DESCRIPTION
## Description
Added `delete()` and `deleteMany()` API. Fixes #67 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] `modelQueries/delete.spec.ts`
- [x] `modelQueries/deleteMany.spec.ts`
